### PR TITLE
Fix -h option description

### DIFF
--- a/source/moss/cli/processor.d
+++ b/source/moss/cli/processor.d
@@ -84,6 +84,7 @@ public:
                 std.getopt.config.caseSensitive, "version", "Show the program version and exit",
                 &versionFlag, "D|destdir", "Set the system root", &_rootDirectory);
         _options = result.options;
+        _options[2].help = "Show help information";
 
         popArg(0);
 


### PR DESCRIPTION
Currently if you run moss with no arguments the output is as follows:
/bin/moss: [command] [--options]

Options:
   --version Show the program version and exit
-D --destdir Set the system root
-h    --help This help information.

This is incorrect as adding the option -h will change the output so "this" can't
be the help information. This commit changes the description to the better fitting
"Show help information" which properly describes the option.

Signed-off-by: Sam Smith <sam.henning.smith@protonmail.com>