### PR TITLE
Manual pad instead of Compiler pad

### DIFF
--- a/source/moss/format/binary/record.d
+++ b/source/moss/format/binary/record.d
@@ -77,7 +77,7 @@ struct Record
     @autoEndian uint16_t length; /** 2 bytes per record length*/
     @autoEndian RecordTag tag; /** 2 bytes for the tag */
     @autoEndian RecordType type; /** 1 byte for the type */
-    ubyte[2] padding;
+    ubyte[3] padding;
 };
 
 static assert(Record.sizeof == 8,


### PR DESCRIPTION
The compiler will pad this struct by one extra byte. To reduce confusion
we should manually pad to the full 8 bytes. I assume ikey thought that
RecordType was 2 bytes when he added the current padding of 2 bytes. That would yeild:
2 (length) + 2 (tag) + 2 (type) + 2 bytes of padding = 8 bytes.

But actually the type is only 1 byte and so the whole data structure is 7 bytes.
Except it isn't, since the biggest data type in the struct is 2 bytes the length
of the struct must be padded to the nearest multiple 2. That means there is a
hidden byte of padding added by the compiler that I have now made manual to avoid
confusion.

Signed-off-by: Sam Smith <sam.henning.smith@protonmail.com>